### PR TITLE
feat: Add interactive API playground with graph visualization

### DIFF
--- a/server/PLAYGROUND.md
+++ b/server/PLAYGROUND.md
@@ -1,0 +1,62 @@
+# Graphiti API Playground
+
+A web-based interface for testing and visualizing the Graphiti knowledge graph API.
+
+## Features
+
+### 🌐 Graph Visualization (Top Section)
+- Interactive knowledge graph display using vis.js
+- Real-time updates when new data is added
+- Click nodes to see details
+- Double-click to focus on a node
+- Filter by group ID
+- Auto-refresh every 30 seconds
+
+### 🧪 API Testing Interface (Bottom Section)
+- **Messages Tab**: Add conversational data to build the knowledge graph
+- **Search Tab**: Query facts using semantic search
+- **Episodes Tab**: Retrieve conversation history
+- **Entity Tab**: Manually add entity nodes
+- **Memory Tab**: Get contextual memory based on messages
+- **Management Tab**: Delete operations and data clearing
+
+## Access
+
+Open your browser and navigate to: http://localhost:8000
+
+## Quick Start
+
+1. **Add Messages**: Use the Messages tab to add some sample data
+2. **View Graph**: The graph visualization will update automatically
+3. **Search**: Use the Search tab to find facts
+4. **Explore**: Click on nodes in the graph to see details
+
+## API Endpoints
+
+- `POST /messages` - Ingest conversational messages
+- `POST /search` - Search for facts in the knowledge graph
+- `GET /episodes/{group_id}` - Retrieve episode history
+- `POST /entity-node` - Add custom entity nodes
+- `POST /get-memory` - Get contextual memory
+- `DELETE /group/{group_id}` - Delete a group and all its data
+- `DELETE /episode/{uuid}` - Delete a specific episode
+- `DELETE /entity-edge/{uuid}` - Delete a specific edge
+- `POST /clear` - Clear all data (use with caution!)
+
+## Visualization
+
+The graph uses different colors for different entity types:
+- 🟦 Default entities (blue)
+- 🟩 People (green)
+- 🔴 Organizations (red)
+- 🟣 Technology (purple)
+- 🟡 Projects (yellow)
+- 🔵 Concepts (light blue)
+
+## Tips
+
+- All JSON inputs are automatically formatted on blur
+- Press Enter in input fields to execute requests
+- Responses are syntax-highlighted for easy reading
+- The graph auto-refreshes every 30 seconds
+- Use the group filter to focus on specific data sets

--- a/server/graph_service/main.py
+++ b/server/graph_service/main.py
@@ -1,11 +1,12 @@
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from graph_service.config import get_settings
 from graph_service.routers import ingest, retrieve
-from graph_service.zep_graphiti import initialize_graphiti
+from graph_service.zep_graphiti import initialize_graphiti, ZepGraphitiDep
 
 
 @asynccontextmanager
@@ -19,11 +20,69 @@ async def lifespan(_: FastAPI):
 
 app = FastAPI(lifespan=lifespan)
 
+# Mount static files
+app.mount("/static", StaticFiles(directory="static"), name="static")
 
 app.include_router(retrieve.router)
 app.include_router(ingest.router)
 
 
+@app.get('/')
+async def root():
+    return FileResponse('static/index.html')
+
+
 @app.get('/healthcheck')
 async def healthcheck():
     return JSONResponse(content={'status': 'healthy'}, status_code=200)
+
+
+@app.get('/graph-data')
+async def get_graph_data(graphiti: ZepGraphitiDep, group_id: str | None = None):
+    """Get graph data for visualization"""
+    # Query for nodes
+    query = """
+    MATCH (n:Entity)
+    WHERE n.group_id IS NOT NULL
+    """ + (f"AND n.group_id = '{group_id}'" if group_id else "") + """
+    RETURN n.uuid as id, n.name as label, n.group_id as group, 
+           labels(n) as labels, n.summary as summary
+    LIMIT 100
+    """
+    
+    nodes_result = await graphiti.driver.query(query)
+    
+    # Query for relationships
+    rel_query = """
+    MATCH (n:Entity)-[r:RELATES_TO]->(m:Entity)
+    WHERE n.group_id IS NOT NULL AND m.group_id IS NOT NULL
+    """ + (f"AND n.group_id = '{group_id}' AND m.group_id = '{group_id}'" if group_id else "") + """
+    RETURN n.uuid as source, m.uuid as target, r.fact as label, type(r) as type
+    LIMIT 200
+    """
+    
+    edges_result = await graphiti.driver.query(rel_query)
+    
+    nodes = [dict(node) for node in nodes_result]
+    edges = [dict(edge) for edge in edges_result]
+    
+    return JSONResponse(content={
+        'nodes': nodes,
+        'edges': edges
+    })
+
+
+@app.get('/stats')
+async def get_stats(graphiti: ZepGraphitiDep):
+    """Get graph statistics"""
+    stats_query = """
+    MATCH (n:Entity) WITH count(n) as entity_count
+    MATCH (e:Episodic) WITH entity_count, count(e) as episode_count
+    MATCH ()-[r:RELATES_TO]->() WITH entity_count, episode_count, count(r) as relation_count
+    RETURN entity_count, episode_count, relation_count
+    """
+    
+    result = await graphiti.driver.query(stats_query)
+    stats = dict(result[0]) if result else {'entity_count': 0, 'episode_count': 0, 'relation_count': 0}
+    
+    return JSONResponse(content=stats)

--- a/server/static/css/style.css
+++ b/server/static/css/style.css
@@ -1,0 +1,311 @@
+/* Global Styles */
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+    background-color: #0d1117;
+    color: #c9d1d9;
+    line-height: 1.6;
+}
+
+.container {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 0;
+    border-bottom: 1px solid #30363d;
+    margin-bottom: 30px;
+}
+
+h1 {
+    font-size: 2rem;
+    color: #58a6ff;
+}
+
+.stats {
+    display: flex;
+    gap: 30px;
+    font-size: 0.9rem;
+    color: #8b949e;
+}
+
+.stats strong {
+    color: #58a6ff;
+    font-size: 1.2rem;
+}
+
+/* Sections */
+section {
+    background-color: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 20px;
+    margin-bottom: 30px;
+}
+
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 20px;
+}
+
+h2 {
+    color: #f0f6fc;
+    font-size: 1.5rem;
+}
+
+h3 {
+    color: #f0f6fc;
+    font-size: 1.2rem;
+    margin-bottom: 15px;
+}
+
+/* Graph Visualization */
+#graph-container {
+    height: 400px;
+    background-color: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+}
+
+.controls {
+    display: flex;
+    gap: 10px;
+}
+
+.controls input {
+    padding: 8px 12px;
+    background-color: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+    width: 200px;
+}
+
+.controls button {
+    padding: 8px 16px;
+    background-color: #238636;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.9rem;
+}
+
+.controls button:hover {
+    background-color: #2ea043;
+}
+
+/* Tabs */
+.tabs {
+    display: flex;
+    gap: 5px;
+    margin-bottom: 20px;
+    border-bottom: 1px solid #30363d;
+}
+
+.tab {
+    padding: 10px 20px;
+    background: none;
+    border: none;
+    color: #8b949e;
+    cursor: pointer;
+    font-size: 0.95rem;
+    border-bottom: 2px solid transparent;
+    transition: all 0.2s;
+}
+
+.tab:hover {
+    color: #c9d1d9;
+}
+
+.tab.active {
+    color: #58a6ff;
+    border-bottom-color: #58a6ff;
+}
+
+.tab-pane {
+    display: none;
+}
+
+.tab-pane.active {
+    display: block;
+}
+
+/* Inputs and Forms */
+.endpoint-info {
+    background-color: #0d1117;
+    padding: 8px 12px;
+    border-radius: 6px;
+    font-family: monospace;
+    font-size: 0.9rem;
+    color: #58a6ff;
+    margin-bottom: 15px;
+}
+
+.json-input {
+    width: 100%;
+    padding: 15px;
+    background-color: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+    font-family: 'Consolas', 'Monaco', monospace;
+    font-size: 0.9rem;
+    resize: vertical;
+    margin-bottom: 15px;
+}
+
+.input-group {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+}
+
+.input-group input {
+    flex: 1;
+    padding: 10px;
+    background-color: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    color: #c9d1d9;
+}
+
+/* Buttons */
+.execute-btn {
+    background-color: #238636;
+    color: white;
+    border: none;
+    padding: 10px 24px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+    transition: background-color 0.2s;
+}
+
+.execute-btn:hover {
+    background-color: #2ea043;
+}
+
+.danger-btn {
+    background-color: #da3633;
+    color: white;
+    border: none;
+    padding: 10px 24px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 500;
+}
+
+.danger-btn:hover {
+    background-color: #f85149;
+}
+
+/* Management Controls */
+.management-controls {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 30px;
+}
+
+.control-group {
+    background-color: #0d1117;
+    padding: 20px;
+    border-radius: 6px;
+    border: 1px solid #30363d;
+}
+
+.control-group h4 {
+    color: #f0f6fc;
+    margin-bottom: 15px;
+}
+
+.control-group button {
+    background-color: #21262d;
+    color: #c9d1d9;
+    border: 1px solid #30363d;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    width: 100%;
+}
+
+.control-group button:hover {
+    background-color: #30363d;
+}
+
+/* Response Section */
+.response-section {
+    margin-top: 30px;
+}
+
+#response-output {
+    background-color: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 20px;
+    overflow-x: auto;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+#response-output code {
+    background: none !important;
+    padding: 0 !important;
+}
+
+/* Loading State */
+.loading {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.loading::after {
+    content: " Loading...";
+    color: #58a6ff;
+}
+
+/* Error State */
+.error {
+    border-color: #f85149 !important;
+    background-color: rgba(248, 81, 73, 0.1) !important;
+}
+
+/* Success State */
+.success {
+    border-color: #3fb950 !important;
+    background-color: rgba(63, 185, 80, 0.1) !important;
+}
+
+/* Scrollbar Styling */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: #0d1117;
+}
+
+::-webkit-scrollbar-thumb {
+    background: #30363d;
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #484f58;
+}

--- a/server/static/index.html
+++ b/server/static/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Graphiti API Playground</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>🌐 Graphiti API Playground</h1>
+            <div class="stats" id="stats">
+                <span>Entities: <strong id="entity-count">0</strong></span>
+                <span>Episodes: <strong id="episode-count">0</strong></span>
+                <span>Relations: <strong id="relation-count">0</strong></span>
+            </div>
+        </header>
+
+        <!-- Graph Visualization Section -->
+        <section class="visualization-section">
+            <div class="section-header">
+                <h2>Knowledge Graph Visualization</h2>
+                <div class="controls">
+                    <input type="text" id="group-filter" placeholder="Filter by group ID...">
+                    <button onclick="refreshGraph()">🔄 Refresh</button>
+                </div>
+            </div>
+            <div id="graph-container"></div>
+        </section>
+
+        <!-- API Testing Section -->
+        <section class="api-section">
+            <h2>API Testing Interface</h2>
+            
+            <!-- Tabs -->
+            <div class="tabs">
+                <button class="tab active" onclick="switchTab('messages')">📝 Messages</button>
+                <button class="tab" onclick="switchTab('search')">🔍 Search</button>
+                <button class="tab" onclick="switchTab('episodes')">📚 Episodes</button>
+                <button class="tab" onclick="switchTab('entity')">🏷️ Entity</button>
+                <button class="tab" onclick="switchTab('memory')">🧠 Memory</button>
+                <button class="tab" onclick="switchTab('management')">⚙️ Management</button>
+            </div>
+
+            <!-- Tab Content -->
+            <div class="tab-content">
+                <!-- Messages Tab -->
+                <div id="messages-tab" class="tab-pane active">
+                    <h3>Add Messages</h3>
+                    <div class="endpoint-info">POST /messages</div>
+                    <textarea id="messages-input" class="json-input" rows="15">{
+  "group_id": "test-group-001",
+  "messages": [
+    {
+      "content": "Sarah is a data scientist at DataCorp. She specializes in neural networks.",
+      "role_type": "user",
+      "role": "Sarah",
+      "timestamp": "2025-08-02T14:00:00Z",
+      "name": "Sarah Introduction"
+    },
+    {
+      "content": "John is Sarah's manager. He leads the AI research team.",
+      "role_type": "user",
+      "role": "John",
+      "timestamp": "2025-08-02T14:05:00Z",
+      "name": "John Introduction"
+    }
+  ]
+}</textarea>
+                    <button onclick="executeRequest('messages')" class="execute-btn">Execute Request</button>
+                </div>
+
+                <!-- Search Tab -->
+                <div id="search-tab" class="tab-pane">
+                    <h3>Search Facts</h3>
+                    <div class="endpoint-info">POST /search</div>
+                    <textarea id="search-input" class="json-input" rows="8">{
+  "group_ids": ["test-group-001"],
+  "query": "Who works with AI?",
+  "max_facts": 10
+}</textarea>
+                    <button onclick="executeRequest('search')" class="execute-btn">Execute Request</button>
+                </div>
+
+                <!-- Episodes Tab -->
+                <div id="episodes-tab" class="tab-pane">
+                    <h3>Get Episodes</h3>
+                    <div class="endpoint-info">GET /episodes/{group_id}</div>
+                    <div class="input-group">
+                        <input type="text" id="episodes-group-id" placeholder="Group ID" value="test-group-001">
+                        <input type="number" id="episodes-last-n" placeholder="Last N" value="10">
+                    </div>
+                    <button onclick="executeRequest('episodes')" class="execute-btn">Execute Request</button>
+                </div>
+
+                <!-- Entity Tab -->
+                <div id="entity-tab" class="tab-pane">
+                    <h3>Add Entity Node</h3>
+                    <div class="endpoint-info">POST /entity-node</div>
+                    <textarea id="entity-input" class="json-input" rows="8">{
+  "uuid": "custom-entity-001",
+  "group_id": "test-group-001",
+  "name": "Machine Learning Team",
+  "summary": "A team focused on developing ML solutions"
+}</textarea>
+                    <button onclick="executeRequest('entity')" class="execute-btn">Execute Request</button>
+                </div>
+
+                <!-- Memory Tab -->
+                <div id="memory-tab" class="tab-pane">
+                    <h3>Get Memory</h3>
+                    <div class="endpoint-info">POST /get-memory</div>
+                    <textarea id="memory-input" class="json-input" rows="12">{
+  "group_id": "test-group-001",
+  "max_facts": 10,
+  "center_node_uuid": null,
+  "messages": [
+    {
+      "content": "Tell me about the team",
+      "role_type": "user",
+      "role": "User"
+    }
+  ]
+}</textarea>
+                    <button onclick="executeRequest('memory')" class="execute-btn">Execute Request</button>
+                </div>
+
+                <!-- Management Tab -->
+                <div id="management-tab" class="tab-pane">
+                    <h3>Management Operations</h3>
+                    <div class="management-controls">
+                        <div class="control-group">
+                            <h4>Delete Operations</h4>
+                            <div class="input-group">
+                                <input type="text" id="delete-group-id" placeholder="Group ID to delete">
+                                <button onclick="deleteGroup()">Delete Group</button>
+                            </div>
+                            <div class="input-group">
+                                <input type="text" id="delete-episode-uuid" placeholder="Episode UUID to delete">
+                                <button onclick="deleteEpisode()">Delete Episode</button>
+                            </div>
+                            <div class="input-group">
+                                <input type="text" id="delete-edge-uuid" placeholder="Edge UUID to delete">
+                                <button onclick="deleteEdge()">Delete Edge</button>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <h4>Clear All Data</h4>
+                            <button onclick="clearAllData()" class="danger-btn">⚠️ Clear All Data</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Response Section -->
+            <div class="response-section">
+                <h3>Response</h3>
+                <pre id="response-output"><code class="language-json">Response will appear here...</code></pre>
+            </div>
+        </section>
+    </div>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+    <script src="/static/js/graph-viz.js"></script>
+    <script src="/static/js/app.js"></script>
+</body>
+</html>

--- a/server/static/js/app.js
+++ b/server/static/js/app.js
@@ -1,0 +1,218 @@
+// API Playground functionality
+
+// Switch between tabs
+function switchTab(tabName) {
+    // Update tab buttons
+    document.querySelectorAll('.tab').forEach(tab => {
+        tab.classList.remove('active');
+    });
+    event.target.classList.add('active');
+    
+    // Update tab content
+    document.querySelectorAll('.tab-pane').forEach(pane => {
+        pane.classList.remove('active');
+    });
+    document.getElementById(`${tabName}-tab`).classList.add('active');
+}
+
+// Execute API request based on tab
+async function executeRequest(endpoint) {
+    const responseOutput = document.getElementById('response-output');
+    responseOutput.innerHTML = '<code class="language-json">Loading...</code>';
+    
+    try {
+        let response;
+        
+        switch(endpoint) {
+            case 'messages':
+                const messagesData = JSON.parse(document.getElementById('messages-input').value);
+                response = await fetch('/messages', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(messagesData)
+                });
+                // Refresh graph after adding messages
+                setTimeout(() => {
+                    const groupId = messagesData.group_id;
+                    document.getElementById('group-filter').value = groupId;
+                    loadGraphData(groupId);
+                    updateStats();
+                }, 2000);
+                break;
+                
+            case 'search':
+                const searchData = JSON.parse(document.getElementById('search-input').value);
+                response = await fetch('/search', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(searchData)
+                });
+                break;
+                
+            case 'episodes':
+                const groupId = document.getElementById('episodes-group-id').value;
+                const lastN = document.getElementById('episodes-last-n').value;
+                response = await fetch(`/episodes/${groupId}?last_n=${lastN}`);
+                break;
+                
+            case 'entity':
+                const entityData = JSON.parse(document.getElementById('entity-input').value);
+                response = await fetch('/entity-node', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(entityData)
+                });
+                // Refresh graph after adding entity
+                setTimeout(() => {
+                    loadGraphData(entityData.group_id);
+                    updateStats();
+                }, 1000);
+                break;
+                
+            case 'memory':
+                const memoryData = JSON.parse(document.getElementById('memory-input').value);
+                response = await fetch('/get-memory', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(memoryData)
+                });
+                break;
+        }
+        
+        const data = await response.json();
+        displayResponse(data, response.ok);
+        
+    } catch (error) {
+        displayResponse({ error: error.message }, false);
+    }
+}
+
+// Management operations
+async function deleteGroup() {
+    const groupId = document.getElementById('delete-group-id').value.trim();
+    if (!groupId) {
+        alert('Please enter a group ID');
+        return;
+    }
+    
+    if (!confirm(`Are you sure you want to delete group: ${groupId}?`)) {
+        return;
+    }
+    
+    try {
+        const response = await fetch(`/group/${groupId}`, { method: 'DELETE' });
+        const data = await response.json();
+        displayResponse(data, response.ok);
+        
+        if (response.ok) {
+            refreshGraph();
+        }
+    } catch (error) {
+        displayResponse({ error: error.message }, false);
+    }
+}
+
+async function deleteEpisode() {
+    const uuid = document.getElementById('delete-episode-uuid').value.trim();
+    if (!uuid) {
+        alert('Please enter an episode UUID');
+        return;
+    }
+    
+    try {
+        const response = await fetch(`/episode/${uuid}`, { method: 'DELETE' });
+        const data = await response.json();
+        displayResponse(data, response.ok);
+        
+        if (response.ok) {
+            refreshGraph();
+        }
+    } catch (error) {
+        displayResponse({ error: error.message }, false);
+    }
+}
+
+async function deleteEdge() {
+    const uuid = document.getElementById('delete-edge-uuid').value.trim();
+    if (!uuid) {
+        alert('Please enter an edge UUID');
+        return;
+    }
+    
+    try {
+        const response = await fetch(`/entity-edge/${uuid}`, { method: 'DELETE' });
+        const data = await response.json();
+        displayResponse(data, response.ok);
+        
+        if (response.ok) {
+            refreshGraph();
+        }
+    } catch (error) {
+        displayResponse({ error: error.message }, false);
+    }
+}
+
+async function clearAllData() {
+    if (!confirm('⚠️ This will delete ALL data in the graph. Are you sure?')) {
+        return;
+    }
+    
+    if (!confirm('This action cannot be undone. Are you REALLY sure?')) {
+        return;
+    }
+    
+    try {
+        const response = await fetch('/clear', { method: 'POST' });
+        const data = await response.json();
+        displayResponse(data, response.ok);
+        
+        if (response.ok) {
+            refreshGraph();
+        }
+    } catch (error) {
+        displayResponse({ error: error.message }, false);
+    }
+}
+
+// Display response with syntax highlighting
+function displayResponse(data, isSuccess) {
+    const responseOutput = document.getElementById('response-output');
+    const jsonString = JSON.stringify(data, null, 2);
+    
+    responseOutput.innerHTML = `<code class="language-json ${isSuccess ? 'success' : 'error'}">${jsonString}</code>`;
+    Prism.highlightElement(responseOutput.querySelector('code'));
+    
+    // Scroll to response
+    responseOutput.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+}
+
+// Format JSON in textareas
+function formatJSON(textareaId) {
+    try {
+        const textarea = document.getElementById(textareaId);
+        const json = JSON.parse(textarea.value);
+        textarea.value = JSON.stringify(json, null, 2);
+    } catch (e) {
+        // Invalid JSON, leave as is
+    }
+}
+
+// Add event listeners for JSON formatting
+document.addEventListener('DOMContentLoaded', () => {
+    // Format JSON on blur
+    document.querySelectorAll('.json-input').forEach(textarea => {
+        textarea.addEventListener('blur', () => {
+            formatJSON(textarea.id);
+        });
+    });
+    
+    // Handle Enter key in input fields
+    document.querySelectorAll('input[type="text"], input[type="number"]').forEach(input => {
+        input.addEventListener('keypress', (e) => {
+            if (e.key === 'Enter') {
+                const button = input.closest('.tab-pane').querySelector('.execute-btn, button');
+                if (button) button.click();
+            }
+        });
+    });
+});

--- a/server/static/js/graph-viz.js
+++ b/server/static/js/graph-viz.js
@@ -1,0 +1,235 @@
+// Graph Visualization with vis.js
+let network = null;
+let nodes = null;
+let edges = null;
+
+// Initialize the graph
+function initializeGraph() {
+    const container = document.getElementById('graph-container');
+    
+    // Create initial empty datasets
+    nodes = new vis.DataSet([]);
+    edges = new vis.DataSet([]);
+    
+    // Create network
+    const data = { nodes, edges };
+    
+    const options = {
+        nodes: {
+            shape: 'dot',
+            size: 20,
+            font: {
+                size: 14,
+                color: '#c9d1d9'
+            },
+            borderWidth: 2,
+            shadow: true,
+            color: {
+                background: '#58a6ff',
+                border: '#1f6feb',
+                highlight: {
+                    background: '#79c0ff',
+                    border: '#58a6ff'
+                }
+            }
+        },
+        edges: {
+            width: 2,
+            color: {
+                color: '#30363d',
+                highlight: '#58a6ff',
+                hover: '#58a6ff'
+            },
+            font: {
+                size: 12,
+                color: '#8b949e',
+                strokeWidth: 3,
+                strokeColor: '#0d1117'
+            },
+            smooth: {
+                type: 'continuous',
+                roundness: 0.5
+            },
+            arrows: {
+                to: {
+                    enabled: true,
+                    scaleFactor: 0.5
+                }
+            }
+        },
+        physics: {
+            barnesHut: {
+                gravitationalConstant: -8000,
+                centralGravity: 0.3,
+                springLength: 120,
+                springConstant: 0.04,
+                damping: 0.09
+            },
+            stabilization: {
+                iterations: 150
+            }
+        },
+        interaction: {
+            hover: true,
+            tooltipDelay: 100,
+            hideEdgesOnDrag: true
+        }
+    };
+    
+    network = new vis.Network(container, data, options);
+    
+    // Add click event listener
+    network.on("click", function(params) {
+        if (params.nodes.length > 0) {
+            const nodeId = params.nodes[0];
+            const node = nodes.get(nodeId);
+            showNodeDetails(node);
+        }
+    });
+    
+    // Add double click event for centering
+    network.on("doubleClick", function(params) {
+        if (params.nodes.length > 0) {
+            network.focus(params.nodes[0], {
+                scale: 1.5,
+                animation: true
+            });
+        }
+    });
+}
+
+// Load graph data from server
+async function loadGraphData(groupId = null) {
+    try {
+        const url = groupId ? `/graph-data?group_id=${groupId}` : '/graph-data';
+        const response = await fetch(url);
+        const data = await response.json();
+        
+        // Clear existing data
+        nodes.clear();
+        edges.clear();
+        
+        // Process nodes
+        const nodeData = data.nodes.map(node => ({
+            id: node.id,
+            label: node.label || node.name || 'Unknown',
+            title: `<b>${node.label}</b><br>${node.summary || 'No description'}`,
+            group: node.group,
+            size: 25,
+            color: getNodeColor(node.labels)
+        }));
+        
+        // Process edges
+        const edgeData = data.edges.map(edge => ({
+            from: edge.source,
+            to: edge.target,
+            label: edge.label || edge.type,
+            title: edge.label,
+            arrows: 'to'
+        }));
+        
+        // Add to datasets
+        nodes.add(nodeData);
+        edges.add(edgeData);
+        
+        // Fit network to show all nodes
+        setTimeout(() => {
+            network.fit({
+                animation: {
+                    duration: 1000,
+                    easingFunction: 'easeInOutQuad'
+                }
+            });
+        }, 500);
+        
+    } catch (error) {
+        console.error('Error loading graph data:', error);
+        showError('Failed to load graph data');
+    }
+}
+
+// Get node color based on type
+function getNodeColor(labels) {
+    if (!labels || labels.length === 0) {
+        return {
+            background: '#58a6ff',
+            border: '#1f6feb'
+        };
+    }
+    
+    // Different colors for different entity types
+    const colorMap = {
+        'Person': { background: '#3fb950', border: '#238636' },
+        'Organization': { background: '#f85149', border: '#da3633' },
+        'Technology': { background: '#a371f7', border: '#8957e5' },
+        'Project': { background: '#ffd33d', border: '#f9c513' },
+        'Concept': { background: '#79c0ff', border: '#58a6ff' }
+    };
+    
+    // Try to match known types
+    for (const label of labels) {
+        if (colorMap[label]) {
+            return colorMap[label];
+        }
+    }
+    
+    // Default color
+    return {
+        background: '#58a6ff',
+        border: '#1f6feb'
+    };
+}
+
+// Show node details
+function showNodeDetails(node) {
+    alert(`Node: ${node.label}\nID: ${node.id}\nGroup: ${node.group}\n${node.title.replace(/<[^>]*>/g, '')}`);
+}
+
+// Refresh graph
+async function refreshGraph() {
+    const groupId = document.getElementById('group-filter').value.trim();
+    const button = event.target;
+    button.classList.add('loading');
+    button.disabled = true;
+    
+    await loadGraphData(groupId || null);
+    await updateStats();
+    
+    button.classList.remove('loading');
+    button.disabled = false;
+}
+
+// Update statistics
+async function updateStats() {
+    try {
+        const response = await fetch('/stats');
+        const stats = await response.json();
+        
+        document.getElementById('entity-count').textContent = stats.entity_count || 0;
+        document.getElementById('episode-count').textContent = stats.episode_count || 0;
+        document.getElementById('relation-count').textContent = stats.relation_count || 0;
+    } catch (error) {
+        console.error('Error loading stats:', error);
+    }
+}
+
+// Show error message
+function showError(message) {
+    const response = document.getElementById('response-output');
+    response.innerHTML = `<code class="language-json error">${JSON.stringify({ error: message }, null, 2)}</code>`;
+    Prism.highlightElement(response.querySelector('code'));
+}
+
+// Initialize on page load
+document.addEventListener('DOMContentLoaded', () => {
+    initializeGraph();
+    loadGraphData();
+    updateStats();
+    
+    // Auto-refresh every 30 seconds
+    setInterval(() => {
+        const groupId = document.getElementById('group-filter').value.trim();
+        loadGraphData(groupId || null);
+        updateStats();
+    }, 30000);
+});

--- a/server/test_data.json
+++ b/server/test_data.json
@@ -1,0 +1,26 @@
+{
+  "group_id": "test-group-001",
+  "messages": [
+    {
+      "content": "Alice is a software engineer who works at TechCorp. She specializes in Python and machine learning.",
+      "role_type": "user",
+      "role": "Alice",
+      "timestamp": "2025-08-02T10:00:00Z",
+      "name": "Alice Introduction"
+    },
+    {
+      "content": "Bob is Alice's colleague. He's a frontend developer who loves React and TypeScript.",
+      "role_type": "user",
+      "role": "Bob", 
+      "timestamp": "2025-08-02T10:05:00Z",
+      "name": "Bob Introduction"
+    },
+    {
+      "content": "Alice and Bob are working together on a new AI-powered dashboard project for their company.",
+      "role_type": "system",
+      "role": "System",
+      "timestamp": "2025-08-02T10:10:00Z",
+      "name": "Project Context"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a web-based API playground interface for testing Graphiti endpoints
- Implements real-time knowledge graph visualization
- Provides an intuitive way for developers to explore and test the API

## Features

### 🌐 Graph Visualization
- Interactive knowledge graph display using vis.js
- Real-time updates when new data is added
- Click nodes to see details, double-click to focus
- Filter by group ID
- Auto-refresh every 30 seconds

### 🧪 API Testing Interface
- **Messages Tab**: Add conversational data to build the knowledge graph
- **Search Tab**: Query facts using semantic search
- **Episodes Tab**: Retrieve conversation history
- **Entity Tab**: Manually add entity nodes
- **Memory Tab**: Get contextual memory based on messages
- **Management Tab**: Delete operations and data clearing

### 🎨 UI/UX
- Dark theme matching GitHub's design
- Tabbed interface for easy navigation
- Pre-filled example requests
- Syntax-highlighted responses
- Loading states and error handling

## New Endpoints
- `GET /graph-data` - Returns nodes and edges for visualization
- `GET /stats` - Returns graph statistics
- `GET /` - Serves the playground interface

## Testing
1. Access the playground at http://localhost:8000
2. Use the Messages tab to add sample data
3. Watch the graph update in real-time
4. Test search and other endpoints

## Screenshots
[Playground interface with graph visualization and API testing tabs]

## Related Issues
Addresses the need for a visual testing interface for the Graphiti API

🤖 Generated with [Claude Code](https://claude.ai/code)